### PR TITLE
Add button to fill textarea with sample JSON

### DIFF
--- a/src/features/json-formatter/JsonFormatter.tsx
+++ b/src/features/json-formatter/JsonFormatter.tsx
@@ -18,7 +18,25 @@ export default function JsonFormatter() {
     <div className="space-y-6">
       <div className="grid gap-4 md:grid-cols-2">
         <div className="space-y-2">
-          <label className="text-sm font-medium text-neutral-400">Input JSON</label>
+          <div className="flex items-center justify-between">
+            <label className="text-sm font-medium text-neutral-400">Input JSON</label>
+            <button
+              type="button"
+              onClick={() => {
+                const compact = '{"name":"DevToolsHub","version":"1.0.0"}';
+                setInput(compact);
+                try {
+                  const parsed = JSON.parse(compact);
+                  setOutput(JSON.stringify(parsed, null, 2));
+                } catch {
+                  setOutput("invalid json");
+                }
+              }}
+              className="text-xs font-medium text-blue-500 hover:text-blue-400 transition-colors"
+            >
+              Sample
+            </button>
+          </div>
           <textarea
             className="w-full rounded-xl border border-neutral-800 bg-neutral-900 p-4 text-sm font-mono text-white outline-none focus:border-blue-500/50 transition-colors"
             rows={15}


### PR DESCRIPTION
## What changed

- Added a "Fill Sample JSON" button
- Automatically populates textarea with formatted JSON

## Why

Helps users quickly test without manually typing JSON.

## Related issue

Closes #3