### PR TITLE
feat: add UUID generator tool with page and React component

### DIFF
--- a/src/features/uuid-generator/UuidGenerator.tsx
+++ b/src/features/uuid-generator/UuidGenerator.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+
+export default function UuidGenerator() {
+    const [uuid, setUuid] = useState("");
+    const [copied, setCopied] = useState(false);
+
+    function handleGenerate() {
+        const newUuid = crypto.randomUUID(); 
+        setUuid(newUuid);
+    } 
+
+    function handleCopy() {
+        if (!uuid) return;
+
+        navigator.clipboard.writeText(uuid);
+        setCopied(true);
+
+        setTimeout(() => setCopied(false), 2000);
+    }
+
+    function handleClear() {
+        setUuid("");
+        setCopied(false);
+    }
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="relative">
+                <textarea
+                    readOnly
+                    value={uuid}
+                    placeholder="Generated UUID will appear here"
+                    rows={1}
+                    className="custom-scrollbar w-full rounded-xl border border-neutral-800 bg-neutral-900 p-4 font-mono text-sm text-white outline-none"
+                />
+                {uuid && (
+                    <button
+                        type="button"
+                        onClick={handleCopy}
+                        className="absolute right-4 top-4 rounded bg-neutral-800 px-3 py-1 text-xs text-white hover:bg-neutral-700"
+                    >
+                        {copied ? "Copied" : "Copy"}
+                    </button>
+                )}
+            </div>
+
+            <div className="flex justify-center gap-4">
+                <button 
+                    className="rounded-full px-6 py-2 text-white bg-blue-600 hover:bg-blue-500"
+                    onClick={handleGenerate}
+                >
+                    Generate UUID
+                </button>
+
+                {uuid && (
+                    <button 
+                        className="rounded-full bg-neutral-600 px-6 py-2 text-white hover:bg-neutral-700"
+                        onClick={handleClear}
+                    >
+                        Clear
+                    </button>
+                )}
+            </div>
+        </div>
+    );  
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,6 +27,12 @@ const tools = [
     description: "Encode and decode URL-safe text and query strings.",
     href: "/tools/url-converter",
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.54.54l2-2a5 5 0 0 0-7.07-7.07l-1.14 1.14"/><path d="M14 11a5 5 0 0 0-7.54-.54l-2 2a5 5 0 0 0 7.07 7.07l1.14-1.14"/></svg>`
+  },
+ {
+    name: "UUID Generator",
+    description: "Generate UUID v4 values instantly",
+    href: "/tools/uuid-generator",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.54.54l2-2a5 5 0 0 0-7.07-7.07l-1.14 1.14"/><path d="M14 11a5 5 0 0 0-7.54-.54l-2 2a5 5 0 0 0 7.07 7.07l1.14-1.14"/></svg>`
   }
 ];
 ---

--- a/src/pages/tools/uuid-generator.astro
+++ b/src/pages/tools/uuid-generator.astro
@@ -1,0 +1,12 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import UuidGenerator from "../../features/uuid-generator/UuidGenerator.tsx"
+---
+
+<BaseLayout title="UUID Generator">
+  <h2 class="mb-6 text-2xl font-semibold">
+    UUID Generator
+  </h2>
+
+  <UuidGenerator client:load />
+</BaseLayout>


### PR DESCRIPTION
## Summary
Adds a new UUID v4 generator tool that allows users to generate, copy, and clear UUIDs directly from the UI.

## Changes
- created a React component in `features/uuid-generator`
- added a new page at `/tools/uuid-generator`
- implemented UUID generation using `crypto.randomUUID()`
- added copy-to-clipboard functionality with user feedback
- added clear/reset functionality
- integrated the tool into the homepage tools list

## UI
- matches existing tool layout and styling
- responsive for both desktop and mobile

## Screenshots

### Desktop 

#### UUID page on load:

<img width="857" height="423" alt="2026-05-01_19h36_22" src="https://github.com/user-attachments/assets/f7791bdc-5e91-4714-a1c3-548e7fa12878" />

#### UUID generated:

<img width="801" height="421" alt="2026-05-01_19h36_40" src="https://github.com/user-attachments/assets/e10edfdc-961d-4339-8db2-0cdfbeb8ad09" />

#### Homepage:

<img width="894" height="436" alt="2026-05-01_19h44_23" src="https://github.com/user-attachments/assets/32361429-bd05-4dc8-b96d-e00b8be77c0f" />

### Mobile

#### UUID page on load:

<img width="190" height="294" alt="2026-05-01_19h37_21" src="https://github.com/user-attachments/assets/423b322e-59cd-4065-b1f9-5053dc7d581f" />

#### UUID generated:

<img width="196" height="281" alt="2026-05-01_19h37_09" src="https://github.com/user-attachments/assets/83ea727b-f96a-486f-8291-18f3e51e5d08" />

#### Homepage:

<img width="193" height="381" alt="2026-05-01_19h43_20" src="https://github.com/user-attachments/assets/b12312ca-1ae2-4f8b-90da-1059e918c62e" />

## Notes
* Follows existing patterns used across tools for consistency and minimal client-side logic
* Currently reuses the URL Encoder and Decoder icon as a temporary placeholder for the UUID tool to maintain visual consistency with existing components
* Happy to make adjustments if needed
* Closes issue #18 