### PR TITLE
fix: standardize error messages across converters

### DIFF
--- a/src/features/base64-converter/Base64Converter.tsx
+++ b/src/features/base64-converter/Base64Converter.tsx
@@ -11,7 +11,7 @@ export default function Base64Converter() {
   const [output, setOutput] = useState("");
 
   const hasInput = input.trim().length > 0;
-  const canUseOutput = output && output !== "invalid base64";
+  const canUseOutput = output && output !== "Invalid Base64 string";
 
   function encodeBase64() {
     try {
@@ -25,7 +25,7 @@ export default function Base64Converter() {
     try {
       setOutput(atob(input));
     } catch {
-      setOutput("invalid base64");
+      setOutput("Invalid Base64 string");
     }
   }
 

--- a/src/features/json-formatter/JsonFormatter.tsx
+++ b/src/features/json-formatter/JsonFormatter.tsx
@@ -9,7 +9,7 @@ export default function JsonFormatter() {
   const [input, setInput] = useState("");
   const [output, setOutput] = useState("");
 
-  const canUseOutput = output && output !== "invalid json";
+  const canUseOutput = output && output !== "Invalid JSON format";
 
   const hasInput = input.trim().length > 0;
 
@@ -18,7 +18,7 @@ export default function JsonFormatter() {
       const parsed = JSON.parse(input);
       setOutput(JSON.stringify(parsed, null, 2));
     } catch {
-      setOutput("invalid json");
+      setOutput("Invalid JSON format");
     }
   }
 
@@ -31,7 +31,7 @@ export default function JsonFormatter() {
       const parsed = JSON.parse(compact);
       setOutput(JSON.stringify(parsed, null, 2));
     } catch {
-      setOutput("invalid json");
+      setOutput("Invalid JSON format");
     }
   }
 

--- a/src/features/jwt-decoder/JWTDecoder.tsx
+++ b/src/features/jwt-decoder/JWTDecoder.tsx
@@ -58,7 +58,7 @@ export default function JWTDecoder() {
       const parts = token.split(".");
 
       if (parts.length !== 3) {
-        throw new Error("invalid jwt");
+        throw new Error("Invalid JWT token");
       }
 
       setDecoded({
@@ -72,7 +72,7 @@ export default function JWTDecoder() {
         header: null,
         payload: null,
         signature: "",
-        error: "invalid jwt",
+        error: "Invalid JWT token",
       });
     }
   }
@@ -97,7 +97,7 @@ export default function JWTDecoder() {
         header: null,
         payload: null,
         signature: "",
-        error: "invalid jwt",
+        error: "Invalid JWT token",
       });
     }
   }

--- a/src/features/timestamp-converter/TimestampConverter.tsx
+++ b/src/features/timestamp-converter/TimestampConverter.tsx
@@ -71,7 +71,7 @@ export default function TimestampConverter() {
         utc: "",
         seconds: "",
         milliseconds: "",
-        error: "invalid input",
+        error: "Invalid timestamp format",
       });
     }
   }

--- a/src/features/url-converter/UrlConverter.tsx
+++ b/src/features/url-converter/UrlConverter.tsx
@@ -11,7 +11,7 @@ export default function UrlConverter() {
   const [encodeFullUrl, setEncodeFullUrl] = useState(true);
 
   const hasInput = input.trim().length > 0;
-  const canUseOutput = output && output !== "invalid input";
+  const canUseOutput = output && output !== "Unable to encode URL" && output !== "Invalid encoded URL";
 
   function encodeQueryValues(value: string) {
     const url = new URL(value);
@@ -31,7 +31,7 @@ export default function UrlConverter() {
 
       setOutput(result);
     } catch {
-      setOutput("invalid input");
+      setOutput("Unable to encode URL");
     }
   }
 
@@ -39,7 +39,7 @@ export default function UrlConverter() {
     try {
       setOutput(decodeURIComponent(input));
     } catch {
-      setOutput("invalid input");
+      setOutput("Invalid encoded URL");
     }
   }
 


### PR DESCRIPTION
## Summary
Improves error handling across multiple tools by replacing generic error messages with clearer, tool-specific feedback.

## Changes
- Updated JSON Formatter to show `"Invalid JSON format"`
- Updated Base64 Converter to show `"Invalid Base64 string"`
- Updated JWT Decoder to show `"Invalid JWT token"`
- Updated Timestamp Converter to show `"Invalid timestamp format"`
- Updated URL Converter to show `"Invalid encoded URL"` and `"Unable to encode URL"`

## related issue
closes #16
