### PR TITLE
Add Diff Checker tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Our goal is to make common developer tasks simpler while keeping your data safe.
 - **JWT Decoder**: Decode and inspect JSON Web Tokens locally.
 - **Base64 Converter**: Encode and decode text to Base64 format.
 - **URL Converter**: Safely encode or decode URL components.
+- **Diff Checker**: Compare text, code, JSON, or config side by side.
 - **Timestamp Converter**: Convert between Unix timestamps and readable dates.
 - **UUID Generator**: Create secure, random UUIDs (v4).
 - **Beautiful Dark Mode**: A sleek design that is easy on the eyes.
@@ -77,4 +78,3 @@ We welcome contributions of all kinds! Whether it's a bug fix or a new tool, we 
 ## 📄 License
 
 This project is open-source and available under the [MIT License](./LICENSE).
-

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -22,6 +22,9 @@
     <loc>https://devtools-hub-beryl.vercel.app/tools/url-converter</loc>
   </url>
   <url>
+    <loc>https://devtools-hub-beryl.vercel.app/tools/diff-checker</loc>
+  </url>
+  <url>
     <loc>https://devtools-hub-beryl.vercel.app/tools/uuid-generator</loc>
   </url>
 </urlset>

--- a/src/constants/tools.ts
+++ b/src/constants/tools.ts
@@ -25,6 +25,12 @@ export const tools: Tool[] = [
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.54.54l2-2a5 5 0 0 0-7.07-7.07l-1.14 1.14"/><path d="M14 11a5 5 0 0 0-7.54-.54l-2 2a5 5 0 0 0 7.07 7.07l1.14-1.14"/></svg>`,
   },
   {
+    name: "Diff Checker",
+    description: "Compare text side by side and highlight added, removed, and changed lines.",
+    href: "/tools/diff-checker",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 4v16"/><path d="M18 4v16"/><path d="M9 8h4"/><path d="M11 12h4"/><path d="M9 16h6"/></svg>`,
+  },
+  {
     name: "UUID Generator",
     description: "Generate UUID v4 values instantly",
     href: "/tools/uuid-generator",

--- a/src/features/diff-checker/DiffChecker.tsx
+++ b/src/features/diff-checker/DiffChecker.tsx
@@ -254,20 +254,20 @@ function getStats(rows: DiffRow[]) {
 
 function getCellClass(row: DiffRow, side: "left" | "right") {
   if (row.kind === "added" && side === "right") {
-    return "border-emerald-500/20 bg-emerald-500/10 text-emerald-100";
+    return "border-success-border bg-success-bg text-success";
   }
 
   if (row.kind === "removed" && side === "left") {
-    return "border-red-500/20 bg-red-500/10 text-red-100";
+    return "border-danger-border bg-danger-bg text-danger";
   }
 
   if (row.kind === "changed") {
     return side === "left"
-      ? "border-amber-500/20 bg-amber-500/10 text-amber-100"
-      : "border-blue-500/20 bg-blue-500/10 text-blue-100";
+      ? "border-warning-border bg-warning-bg text-warning"
+      : "border-accent/20 bg-accent-bg text-accent";
   }
 
-  return "border-neutral-800 bg-neutral-950/30 text-neutral-300";
+  return "border-border bg-ground/30 text-secondary";
 }
 
 function DiffCell({
@@ -284,7 +284,7 @@ function DiffCell({
     <div
       className={`grid min-h-10 grid-cols-[4rem_1fr] border-b md:border-b-0 ${getCellClass(row, side)}`}
     >
-      <div className="select-none border-r border-inherit px-3 py-2 text-right font-mono text-xs text-neutral-500">
+      <div className="select-none border-r border-inherit px-3 py-2 text-right font-mono text-xs text-muted">
         {lineNumber ?? ""}
       </div>
       <pre className="custom-scrollbar overflow-x-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-xs leading-5">
@@ -345,27 +345,27 @@ export default function DiffChecker() {
       )}
 
       <div className="grid gap-3 sm:grid-cols-4">
-        <div className="rounded-xl border border-neutral-800 bg-neutral-900 p-4">
-          <div className="text-xs uppercase text-neutral-500">Rows</div>
-          <div className="mt-1 text-2xl font-semibold text-white">{rows.length}</div>
+        <div className="rounded-xl border border-border bg-surface p-4">
+          <div className="text-xs uppercase text-muted">Rows</div>
+          <div className="mt-1 text-2xl font-semibold text-primary">{rows.length}</div>
         </div>
-        <div className="rounded-xl border border-neutral-800 bg-neutral-900 p-4">
-          <div className="text-xs uppercase text-neutral-500">Added</div>
-          <div className="mt-1 text-2xl font-semibold text-emerald-300">{stats.added}</div>
+        <div className="rounded-xl border border-border bg-surface p-4">
+          <div className="text-xs uppercase text-muted">Added</div>
+          <div className="mt-1 text-2xl font-semibold text-success">{stats.added}</div>
         </div>
-        <div className="rounded-xl border border-neutral-800 bg-neutral-900 p-4">
-          <div className="text-xs uppercase text-neutral-500">Removed</div>
-          <div className="mt-1 text-2xl font-semibold text-red-300">{stats.removed}</div>
+        <div className="rounded-xl border border-border bg-surface p-4">
+          <div className="text-xs uppercase text-muted">Removed</div>
+          <div className="mt-1 text-2xl font-semibold text-danger">{stats.removed}</div>
         </div>
-        <div className="rounded-xl border border-neutral-800 bg-neutral-900 p-4">
-          <div className="text-xs uppercase text-neutral-500">Changed</div>
-          <div className="mt-1 text-2xl font-semibold text-amber-300">{stats.changed}</div>
+        <div className="rounded-xl border border-border bg-surface p-4">
+          <div className="text-xs uppercase text-muted">Changed</div>
+          <div className="mt-1 text-2xl font-semibold text-warning">{stats.changed}</div>
         </div>
       </div>
 
-      <section className="overflow-hidden rounded-xl border border-neutral-800 bg-neutral-900">
-        <div className="grid border-b border-neutral-800 bg-neutral-950/60 text-sm font-semibold text-neutral-300 md:grid-cols-2">
-          <div className="border-b border-neutral-800 px-4 py-3 md:border-b-0 md:border-r">
+      <section className="overflow-hidden rounded-xl border border-border bg-surface">
+        <div className="grid border-b border-border bg-elevated text-sm font-semibold text-secondary md:grid-cols-2">
+          <div className="border-b border-border px-4 py-3 md:border-b-0 md:border-r">
             Original
           </div>
           <div className="px-4 py-3">Changed</div>
@@ -376,7 +376,7 @@ export default function DiffChecker() {
             {rows.map((row, index) => (
               <div
                 key={`${row.kind}-${row.leftLine ?? "x"}-${row.rightLine ?? "x"}-${index}`}
-                className="grid border-b border-neutral-800 last:border-b-0 md:grid-cols-2"
+                className="grid border-b border-border last:border-b-0 md:grid-cols-2"
               >
                 <DiffCell row={row} side="left" />
                 <DiffCell row={row} side="right" />
@@ -384,14 +384,14 @@ export default function DiffChecker() {
             ))}
           </div>
         ) : (
-          <div className="px-4 py-12 text-center text-sm text-neutral-500">
+          <div className="px-4 py-12 text-center text-sm text-muted">
             Paste text into either panel to compare.
           </div>
         )}
       </section>
 
       {hasInput && totalChanges === 0 && (
-        <p className="text-center text-sm text-emerald-300">
+        <p className="text-center text-sm text-success">
           No differences found.
         </p>
       )}

--- a/src/features/diff-checker/DiffChecker.tsx
+++ b/src/features/diff-checker/DiffChecker.tsx
@@ -1,0 +1,400 @@
+import { useMemo, useState } from "react";
+import ToolTextarea from "../../components/tool/ToolTextarea";
+import ToolActions from "../../components/tool/ToolActions";
+import Button from "../../ui/Button";
+import SampleButton from "../../ui/SampleButton";
+
+type DiffKind = "same" | "changed" | "added" | "removed";
+
+type DiffRow = {
+  kind: DiffKind;
+  leftLine?: number;
+  rightLine?: number;
+  leftText: string;
+  rightText: string;
+};
+
+type DiffOperation =
+  | { type: "same"; leftLine: number; rightLine: number; text: string }
+  | { type: "removed"; leftLine: number; text: string }
+  | { type: "added"; rightLine: number; text: string };
+
+const LCS_CELL_LIMIT = 180_000;
+
+const leftSample = `function formatUser(user) {
+  return {
+    id: user.id,
+    name: user.name.trim(),
+    role: "member"
+  };
+}`;
+
+const rightSample = `function formatUser(user) {
+  return {
+    id: user.id,
+    name: user.displayName.trim(),
+    active: true,
+    role: "admin"
+  };
+}`;
+
+function splitLines(value: string) {
+  if (!value) {
+    return [];
+  }
+
+  return value.replace(/\r\n?/g, "\n").split("\n");
+}
+
+function buildDiffRows(leftLines: string[], rightLines: string[]) {
+  if (leftLines.length * rightLines.length > LCS_CELL_LIMIT) {
+    return buildAlignedRows(leftLines, rightLines);
+  }
+
+  return coalesceOperations(buildLcsOperations(leftLines, rightLines));
+}
+
+function buildAlignedRows(leftLines: string[], rightLines: string[]): DiffRow[] {
+  const rowCount = Math.max(leftLines.length, rightLines.length);
+  const rows: DiffRow[] = [];
+
+  for (let index = 0; index < rowCount; index += 1) {
+    const hasLeft = index < leftLines.length;
+    const hasRight = index < rightLines.length;
+    const leftText = hasLeft ? leftLines[index] : "";
+    const rightText = hasRight ? rightLines[index] : "";
+
+    if (hasLeft && hasRight) {
+      rows.push({
+        kind: leftText === rightText ? "same" : "changed",
+        leftLine: index + 1,
+        rightLine: index + 1,
+        leftText,
+        rightText,
+      });
+    } else if (hasLeft) {
+      rows.push({
+        kind: "removed",
+        leftLine: index + 1,
+        leftText,
+        rightText: "",
+      });
+    } else if (hasRight) {
+      rows.push({
+        kind: "added",
+        rightLine: index + 1,
+        leftText: "",
+        rightText,
+      });
+    }
+  }
+
+  return rows;
+}
+
+function buildLcsOperations(
+  leftLines: string[],
+  rightLines: string[],
+): DiffOperation[] {
+  const rows = leftLines.length;
+  const columns = rightLines.length;
+  const matrix = Array.from(
+    { length: rows + 1 },
+    () => new Uint32Array(columns + 1),
+  );
+
+  for (let leftIndex = rows - 1; leftIndex >= 0; leftIndex -= 1) {
+    for (let rightIndex = columns - 1; rightIndex >= 0; rightIndex -= 1) {
+      matrix[leftIndex][rightIndex] =
+        leftLines[leftIndex] === rightLines[rightIndex]
+          ? matrix[leftIndex + 1][rightIndex + 1] + 1
+          : Math.max(
+              matrix[leftIndex + 1][rightIndex],
+              matrix[leftIndex][rightIndex + 1],
+            );
+    }
+  }
+
+  const operations: DiffOperation[] = [];
+  let leftIndex = 0;
+  let rightIndex = 0;
+
+  while (leftIndex < rows && rightIndex < columns) {
+    if (leftLines[leftIndex] === rightLines[rightIndex]) {
+      operations.push({
+        type: "same",
+        leftLine: leftIndex + 1,
+        rightLine: rightIndex + 1,
+        text: leftLines[leftIndex],
+      });
+      leftIndex += 1;
+      rightIndex += 1;
+    } else if (
+      matrix[leftIndex + 1][rightIndex] >= matrix[leftIndex][rightIndex + 1]
+    ) {
+      operations.push({
+        type: "removed",
+        leftLine: leftIndex + 1,
+        text: leftLines[leftIndex],
+      });
+      leftIndex += 1;
+    } else {
+      operations.push({
+        type: "added",
+        rightLine: rightIndex + 1,
+        text: rightLines[rightIndex],
+      });
+      rightIndex += 1;
+    }
+  }
+
+  while (leftIndex < rows) {
+    operations.push({
+      type: "removed",
+      leftLine: leftIndex + 1,
+      text: leftLines[leftIndex],
+    });
+    leftIndex += 1;
+  }
+
+  while (rightIndex < columns) {
+    operations.push({
+      type: "added",
+      rightLine: rightIndex + 1,
+      text: rightLines[rightIndex],
+    });
+    rightIndex += 1;
+  }
+
+  return operations;
+}
+
+function coalesceOperations(operations: DiffOperation[]) {
+  const rows: DiffRow[] = [];
+  let index = 0;
+
+  while (index < operations.length) {
+    const operation = operations[index];
+
+    if (operation.type === "same") {
+      rows.push({
+        kind: "same",
+        leftLine: operation.leftLine,
+        rightLine: operation.rightLine,
+        leftText: operation.text,
+        rightText: operation.text,
+      });
+      index += 1;
+      continue;
+    }
+
+    const removed: Extract<DiffOperation, { type: "removed" }>[] = [];
+    const added: Extract<DiffOperation, { type: "added" }>[] = [];
+
+    while (operations[index]?.type === "removed") {
+      removed.push(operations[index] as Extract<DiffOperation, { type: "removed" }>);
+      index += 1;
+    }
+
+    while (operations[index]?.type === "added") {
+      added.push(operations[index] as Extract<DiffOperation, { type: "added" }>);
+      index += 1;
+    }
+
+    const changedCount = Math.min(removed.length, added.length);
+
+    for (let pairIndex = 0; pairIndex < changedCount; pairIndex += 1) {
+      rows.push({
+        kind: "changed",
+        leftLine: removed[pairIndex].leftLine,
+        rightLine: added[pairIndex].rightLine,
+        leftText: removed[pairIndex].text,
+        rightText: added[pairIndex].text,
+      });
+    }
+
+    for (let removedIndex = changedCount; removedIndex < removed.length; removedIndex += 1) {
+      rows.push({
+        kind: "removed",
+        leftLine: removed[removedIndex].leftLine,
+        leftText: removed[removedIndex].text,
+        rightText: "",
+      });
+    }
+
+    for (let addedIndex = changedCount; addedIndex < added.length; addedIndex += 1) {
+      rows.push({
+        kind: "added",
+        rightLine: added[addedIndex].rightLine,
+        leftText: "",
+        rightText: added[addedIndex].text,
+      });
+    }
+  }
+
+  return rows;
+}
+
+function getStats(rows: DiffRow[]) {
+  return rows.reduce(
+    (stats, row) => {
+      if (row.kind !== "same") {
+        stats[row.kind] += 1;
+      }
+
+      return stats;
+    },
+    {
+      added: 0,
+      removed: 0,
+      changed: 0,
+    },
+  );
+}
+
+function getCellClass(row: DiffRow, side: "left" | "right") {
+  if (row.kind === "added" && side === "right") {
+    return "border-emerald-500/20 bg-emerald-500/10 text-emerald-100";
+  }
+
+  if (row.kind === "removed" && side === "left") {
+    return "border-red-500/20 bg-red-500/10 text-red-100";
+  }
+
+  if (row.kind === "changed") {
+    return side === "left"
+      ? "border-amber-500/20 bg-amber-500/10 text-amber-100"
+      : "border-blue-500/20 bg-blue-500/10 text-blue-100";
+  }
+
+  return "border-neutral-800 bg-neutral-950/30 text-neutral-300";
+}
+
+function DiffCell({
+  row,
+  side,
+}: {
+  row: DiffRow;
+  side: "left" | "right";
+}) {
+  const lineNumber = side === "left" ? row.leftLine : row.rightLine;
+  const text = side === "left" ? row.leftText : row.rightText;
+
+  return (
+    <div
+      className={`grid min-h-10 grid-cols-[4rem_1fr] border-b md:border-b-0 ${getCellClass(row, side)}`}
+    >
+      <div className="select-none border-r border-inherit px-3 py-2 text-right font-mono text-xs text-neutral-500">
+        {lineNumber ?? ""}
+      </div>
+      <pre className="custom-scrollbar overflow-x-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-xs leading-5">
+        {text || " "}
+      </pre>
+    </div>
+  );
+}
+
+export default function DiffChecker() {
+  const [left, setLeft] = useState("");
+  const [right, setRight] = useState("");
+
+  const leftLines = useMemo(() => splitLines(left), [left]);
+  const rightLines = useMemo(() => splitLines(right), [right]);
+  const rows = useMemo(() => buildDiffRows(leftLines, rightLines), [leftLines, rightLines]);
+  const stats = useMemo(() => getStats(rows), [rows]);
+  const hasInput = left.trim().length > 0 || right.trim().length > 0;
+  const totalChanges = stats.added + stats.removed + stats.changed;
+
+  function loadSample() {
+    setLeft(leftSample);
+    setRight(rightSample);
+  }
+
+  function clear() {
+    setLeft("");
+    setRight("");
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2">
+        <ToolTextarea
+          label="Original"
+          value={left}
+          onChange={setLeft}
+          placeholder="Paste original text"
+          rows={14}
+          rightLabel={<SampleButton onClick={loadSample} />}
+        />
+
+        <ToolTextarea
+          label="Changed"
+          value={right}
+          onChange={setRight}
+          placeholder="Paste changed text"
+          rows={14}
+        />
+      </div>
+
+      {hasInput && (
+        <ToolActions>
+          <Button variant="secondary" onClick={clear}>
+            Clear
+          </Button>
+        </ToolActions>
+      )}
+
+      <div className="grid gap-3 sm:grid-cols-4">
+        <div className="rounded-xl border border-neutral-800 bg-neutral-900 p-4">
+          <div className="text-xs uppercase text-neutral-500">Rows</div>
+          <div className="mt-1 text-2xl font-semibold text-white">{rows.length}</div>
+        </div>
+        <div className="rounded-xl border border-neutral-800 bg-neutral-900 p-4">
+          <div className="text-xs uppercase text-neutral-500">Added</div>
+          <div className="mt-1 text-2xl font-semibold text-emerald-300">{stats.added}</div>
+        </div>
+        <div className="rounded-xl border border-neutral-800 bg-neutral-900 p-4">
+          <div className="text-xs uppercase text-neutral-500">Removed</div>
+          <div className="mt-1 text-2xl font-semibold text-red-300">{stats.removed}</div>
+        </div>
+        <div className="rounded-xl border border-neutral-800 bg-neutral-900 p-4">
+          <div className="text-xs uppercase text-neutral-500">Changed</div>
+          <div className="mt-1 text-2xl font-semibold text-amber-300">{stats.changed}</div>
+        </div>
+      </div>
+
+      <section className="overflow-hidden rounded-xl border border-neutral-800 bg-neutral-900">
+        <div className="grid border-b border-neutral-800 bg-neutral-950/60 text-sm font-semibold text-neutral-300 md:grid-cols-2">
+          <div className="border-b border-neutral-800 px-4 py-3 md:border-b-0 md:border-r">
+            Original
+          </div>
+          <div className="px-4 py-3">Changed</div>
+        </div>
+
+        {hasInput ? (
+          <div className="max-h-[38rem] overflow-auto custom-scrollbar">
+            {rows.map((row, index) => (
+              <div
+                key={`${row.kind}-${row.leftLine ?? "x"}-${row.rightLine ?? "x"}-${index}`}
+                className="grid border-b border-neutral-800 last:border-b-0 md:grid-cols-2"
+              >
+                <DiffCell row={row} side="left" />
+                <DiffCell row={row} side="right" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="px-4 py-12 text-center text-sm text-neutral-500">
+            Paste text into either panel to compare.
+          </div>
+        )}
+      </section>
+
+      {hasInput && totalChanges === 0 && (
+        <p className="text-center text-sm text-emerald-300">
+          No differences found.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/tools/diff-checker.astro
+++ b/src/pages/tools/diff-checker.astro
@@ -1,0 +1,13 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import DiffCheckerTool from "../../features/diff-checker/DiffChecker";
+---
+
+<BaseLayout
+  title="Diff Checker | Free Online Developer Tool"
+  description="Compare code, JSON, configuration, and text locally with a fast side-by-side diff checker."
+>
+  <h2 class="mb-6 text-2xl font-semibold">Diff Checker</h2>
+
+  <DiffCheckerTool client:load />
+</BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,8 +16,12 @@
   --color-danger: #f87171;
   --color-danger-bg: rgba(239, 68, 68, 0.1);
   --color-danger-border: rgba(239, 68, 68, 0.2);
+  --color-warning: #fbbf24;
+  --color-warning-bg: rgba(245, 158, 11, 0.1);
+  --color-warning-border: rgba(245, 158, 11, 0.2);
   --color-success: #4ade80;
   --color-success-bg: rgba(34, 197, 94, 0.1);
+  --color-success-border: rgba(34, 197, 94, 0.2);
   --color-header-bg: rgba(15, 17, 21, 0.8);
   --color-search-bg: #151922;
   --color-search-hover: #1a1f2e;
@@ -39,8 +43,12 @@
   --color-danger: #dc2626;
   --color-danger-bg: rgba(239, 68, 68, 0.06);
   --color-danger-border: rgba(239, 68, 68, 0.15);
+  --color-warning: #b45309;
+  --color-warning-bg: rgba(245, 158, 11, 0.08);
+  --color-warning-border: rgba(245, 158, 11, 0.18);
   --color-success: #16a34a;
   --color-success-bg: rgba(34, 197, 94, 0.06);
+  --color-success-border: rgba(34, 197, 94, 0.16);
   --color-header-bg: rgba(248, 250, 252, 0.8);
   --color-search-bg: #ffffff;
   --color-search-hover: #f1f5f9;


### PR DESCRIPTION
## Summary

- add a client-side Diff Checker tool at `/tools/diff-checker`
- compare two editable text inputs in real time and show a side-by-side line diff
- highlight added, removed, and changed rows, then expose the tool in search, the homepage, README, and sitemap

Closes #30.

## Validation

- `npm run build`
- `curl -fsS http://127.0.0.1:4331/tools/diff-checker/ | rg -n "Diff Checker|Paste original text|/tools/diff-checker"`
- `curl -fsS http://127.0.0.1:4331/ | rg -n "Diff Checker|/tools/diff-checker"`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30`

## Notes

- The diff is line-based and stays dependency-free.
- I did not add an automated browser interaction test; the route and homepage listing were smoke-tested through the local preview server.
- AI assistance was used for implementation; I reviewed and validated the final diff locally.
