### PR TITLE
feat: add keyboard navigation to search results

### DIFF
--- a/src/components/tool/Search.tsx
+++ b/src/components/tool/Search.tsx
@@ -25,15 +25,15 @@ export default function Search() {
   }, []);
 
   const filteredTools = query.trim()
-    ? tools.filter((tool) =>
-        tool.name.toLowerCase().includes(query.toLowerCase()) ||
-        tool.description.toLowerCase().includes(query.toLowerCase())
+    ? tools.filter(
+        (tool) =>
+          tool.name.toLowerCase().includes(query.toLowerCase()) ||
+          tool.description.toLowerCase().includes(query.toLowerCase()),
       )
     : [];
 
-  const defaultTools = recentSearches.length > 0 
-    ? recentSearches 
-    : tools.slice(0, 3);
+  const defaultTools =
+    recentSearches.length > 0 ? recentSearches : tools.slice(0, 3);
 
   const displayTools = query.trim() ? filteredTools : defaultTools;
 
@@ -42,10 +42,10 @@ export default function Search() {
       tool,
       ...recentSearches.filter((t) => t.href !== tool.href),
     ].slice(0, 3);
-    
+
     setRecentSearches(updatedRecent);
     localStorage.setItem("recent_tools", JSON.stringify(updatedRecent));
-    
+
     window.location.href = tool.href;
     setIsOpen(false);
   };
@@ -70,12 +70,12 @@ export default function Search() {
       if (event.key === "ArrowDown") {
         event.preventDefault();
         setHighlightedIndex((prev) =>
-          prev < displayTools.length - 1 ? prev + 1 : 0
+          prev < displayTools.length - 1 ? prev + 1 : 0,
         );
       } else if (event.key === "ArrowUp") {
         event.preventDefault();
         setHighlightedIndex((prev) =>
-          prev > 0 ? prev - 1 : displayTools.length - 1
+          prev > 0 ? prev - 1 : displayTools.length - 1,
         );
       } else if (event.key === "Enter" && highlightedIndex >= 0) {
         event.preventDefault();
@@ -88,7 +88,10 @@ export default function Search() {
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
         setIsOpen(false);
       }
     };
@@ -106,8 +109,19 @@ export default function Search() {
     <div ref={containerRef} className="relative w-full max-w-md">
       <div className="relative group">
         <div className="absolute inset-y-0 left-3 flex items-center pointer-events-none text-muted group-focus-within:text-accent transition-colors">
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
           </svg>
         </div>
         <input
@@ -122,7 +136,7 @@ export default function Search() {
           placeholder="Search tools..."
           className="w-full bg-search-bg border border-border text-primary text-sm rounded-xl py-2.5 pl-10 pr-12 outline-none focus:border-accent/50 focus:ring-4 focus:ring-accent/10 transition-all placeholder:text-muted"
         />
-        
+
         <div className="absolute inset-y-0 right-3 flex items-center gap-2">
           {query ? (
             <button
@@ -133,8 +147,19 @@ export default function Search() {
               className="p-1 rounded-md hover:bg-elevated text-muted hover:text-primary transition-colors"
               title="Clear search"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
               </svg>
             </button>
           ) : (
@@ -149,10 +174,14 @@ export default function Search() {
         <div className="absolute top-full left-0 right-0 mt-2 bg-surface border border-border rounded-xl shadow-2xl shadow-black/50 overflow-hidden z-[60] animate-in fade-in slide-in-from-top-2 duration-200">
           <div className="p-2 border-b border-border bg-surface/50 flex justify-between items-center">
             <span className="text-[10px] font-bold uppercase tracking-wider text-muted px-2">
-              {query.trim() ? "Search Results" : recentSearches.length > 0 ? "Recent Tools" : "Suggested Tools"}
+              {query.trim()
+                ? "Search Results"
+                : recentSearches.length > 0
+                  ? "Recent Tools"
+                  : "Suggested Tools"}
             </span>
             {!query.trim() && recentSearches.length > 0 && (
-              <button 
+              <button
                 onClick={clearRecent}
                 className="text-[10px] font-bold uppercase tracking-wider text-muted hover:text-danger px-2 transition-colors"
               >
@@ -160,24 +189,29 @@ export default function Search() {
               </button>
             )}
           </div>
-          
+
           <div className="max-h-[300px] overflow-y-auto custom-scrollbar">
             {displayTools.length > 0 ? (
               displayTools.map((tool, index) => (
                 <button
                   key={tool.href}
                   onClick={() => handleSelect(tool)}
-                  className={`w-full flex items-start gap-3 p-3 text-left hover:bg-search-hover transition-colors group ${
+                  className={`w-full flex items-start gap-3 p-3 text-left transition-colors group ${
                     highlightedIndex === index ? "bg-search-hover" : ""
                   }`}
+                  onMouseEnter={() => setHighlightedIndex(index)}
                 >
-                  <div 
+                  <div
                     className="size-8 rounded-lg bg-elevated text-muted group-hover:bg-accent group-hover:text-white flex items-center justify-center transition-colors shrink-0"
-                    dangerouslySetInnerHTML={{ __html: tool.icon }} 
+                    dangerouslySetInnerHTML={{ __html: tool.icon }}
                   />
                   <div className="min-w-0 flex-1">
-                    <div className="text-sm font-semibold text-primary group-hover:text-accent transition-colors">{tool.name}</div>
-                    <div className="text-xs text-muted line-clamp-1 truncate">{tool.description}</div>
+                    <div className="text-sm font-semibold text-primary group-hover:text-accent transition-colors">
+                      {tool.name}
+                    </div>
+                    <div className="text-xs text-muted line-clamp-1 truncate">
+                      {tool.description}
+                    </div>
                   </div>
                 </button>
               ))
@@ -189,7 +223,9 @@ export default function Search() {
           </div>
 
           <div className="p-2 border-t border-border bg-surface/50 flex justify-between items-center px-4">
-            <span className="text-[10px] text-secondary">Press Esc to close</span>
+            <span className="text-[10px] text-secondary">
+              Press Esc to close
+            </span>
             <span className="text-[10px] text-secondary font-mono">CMD+K</span>
           </div>
         </div>

--- a/src/components/tool/Search.tsx
+++ b/src/components/tool/Search.tsx
@@ -6,6 +6,7 @@ export default function Search() {
   const [isOpen, setIsOpen] = useState(false);
   const [recentSearches, setRecentSearches] = useState<Tool[]>([]);
   const [isMac, setIsMac] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -56,15 +57,34 @@ export default function Search() {
       if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         inputRef.current?.focus();
+        return;
       }
       if (event.key === "Escape") {
         setIsOpen(false);
+        setHighlightedIndex(-1);
         inputRef.current?.blur();
+        return;
+      }
+      if (!isOpen || displayTools.length === 0) return;
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setHighlightedIndex((prev) =>
+          prev < displayTools.length - 1 ? prev + 1 : 0
+        );
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setHighlightedIndex((prev) =>
+          prev > 0 ? prev - 1 : displayTools.length - 1
+        );
+      } else if (event.key === "Enter" && highlightedIndex >= 0) {
+        event.preventDefault();
+        handleSelect(displayTools[highlightedIndex]);
       }
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  }, [isOpen, displayTools, highlightedIndex]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -94,7 +114,10 @@ export default function Search() {
           ref={inputRef}
           type="text"
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setHighlightedIndex(-1);
+          }}
           onFocus={() => setIsOpen(true)}
           placeholder="Search tools..."
           className="w-full bg-search-bg border border-border text-primary text-sm rounded-xl py-2.5 pl-10 pr-12 outline-none focus:border-accent/50 focus:ring-4 focus:ring-accent/10 transition-all placeholder:text-muted"
@@ -140,11 +163,13 @@ export default function Search() {
           
           <div className="max-h-[300px] overflow-y-auto custom-scrollbar">
             {displayTools.length > 0 ? (
-              displayTools.map((tool) => (
+              displayTools.map((tool, index) => (
                 <button
                   key={tool.href}
                   onClick={() => handleSelect(tool)}
-                  className="w-full flex items-start gap-3 p-3 text-left hover:bg-search-hover transition-colors group"
+                  className={`w-full flex items-start gap-3 p-3 text-left hover:bg-search-hover transition-colors group ${
+                    highlightedIndex === index ? "bg-search-hover" : ""
+                  }`}
                 >
                   <div 
                     className="size-8 rounded-lg bg-elevated text-muted group-hover:bg-accent group-hover:text-white flex items-center justify-center transition-colors shrink-0"


### PR DESCRIPTION
## summary

Added keyboard navigation support to the search dropdown so users can navigate results without a mouse.

## changes

- Added `highlightedIndex` state to track the currently selected result
- Extended existing keyboard handler to support ArrowUp, ArrowDown, and Enter
- Arrow Down cycles forward through results; Arrow Up cycles backward
- Enter opens the highlighted tool using the existing `handleSelect` function
- Escape now also resets the highlight index
- Query changes reset the highlight index
- Added visual highlight style (`bg-search-hover`) to the active result item

## related issue

closes #41
