### PR TITLE
feat: improve mobile UX and button placement for JSON Formatter

### DIFF
--- a/src/features/json-formatter/JsonFormatter.tsx
+++ b/src/features/json-formatter/JsonFormatter.tsx
@@ -62,6 +62,7 @@ export default function JsonFormatter() {
   return (
     <div className="space-y-6">
       <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-4">
         <ToolTextarea
           label="Input"
           value={input}
@@ -72,6 +73,25 @@ export default function JsonFormatter() {
             <SampleButton onClick={loadSample} />
           }
         />
+
+        {/* Mobile-only sticky action bar */}
+        <div className="md:hidden sticky bottom-4 z-10 bg-surface/95 backdrop-blur-sm border border-border rounded-xl p-3 shadow-lg">
+          <div className="flex gap-2">
+            <Button
+              variant="primary"
+              onClick={formatJson}
+              isDisabled={!hasInput}
+              className="flex-1"
+            >
+              Format JSON
+            </Button>
+            {output && (
+              <Button variant="secondary" onClick={clear}>
+                Clear
+              </Button>
+            )}
+          </div>
+        </div>
 
         <ToolTextarea
           label="Output"
@@ -86,21 +106,24 @@ export default function JsonFormatter() {
         </ToolTextarea>
       </div>
 
-      <ToolActions>
-        <Button 
-          variant="primary" 
-          onClick={formatJson} 
-          isDisabled={!hasInput}
-        >
-          Format JSON
-        </Button>
-
-        {output && (
-          <Button variant="secondary" onClick={clear}>
-            Clear
+      {/* Desktop-only actions */}
+      <div className="hidden md:block">
+        <ToolActions>
+          <Button
+            variant="primary"
+            onClick={formatJson}
+            isDisabled={!hasInput}
+          >
+            Format JSON
           </Button>
-        )}
-      </ToolActions>
+
+          {output && (
+            <Button variant="secondary" onClick={clear}>
+              Clear
+            </Button>
+          )}
+        </ToolActions>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## summary

Improved mobile UX for the JSON Formatter by adding a sticky action bar on small screens.

## changes

- Added a mobile-only sticky bottom action bar with Format JSON and Clear buttons
- Kept the original desktop layout unchanged
- Buttons are now easily reachable on mobile without scrolling past the output area

## related issue

closes #12
