### PR TITLE
feature: gitignore-generator

### DIFF
--- a/src/constants/tools.ts
+++ b/src/constants/tools.ts
@@ -117,4 +117,11 @@ export const tools: Tool[] = [
     href: "/tools/color-converter",
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r="3"/><circle cx="7.5" cy="13.5" r="3"/><circle cx="16.5" cy="16.5" r="3"/><path d="M10 11.2 12 13"/><path d="M10.4 15.6 12.6 14"/><path d="M15.2 14 16 15.4"/></svg>`,
   },
+  {
+    name: "Gitignore Generator",
+    description:
+      "Generate a customized, production-ready .gitignore file based on the technology you use.",
+    href: "/tools/gitignore-generator",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>`,
+  },
 ];

--- a/src/features/gitignore-generator/GitignoreGenerator.tsx
+++ b/src/features/gitignore-generator/GitignoreGenerator.tsx
@@ -1,0 +1,82 @@
+const GITIGNORE_OUTPUT_LIST = {
+    "Node.js": "node_modules/\nnpm-debug.log*\nyarn-debug.log*\nyarn-error.log*\n.pnpm-debug.log*\n",
+    "React": "node_modules/\nnpm-debug.log*\nyarn-debug.log*\nyarn-error.log*\n.pnpm-debug.log*\ndist/\nbuild/\n.eslintcache\n.env.development.local\n.env.test.local\n.env.production.local\n",
+    "Next.js": "node_modules/\nnpm-debug.log*\nyarn-debug.log*\nyarn-error.log*\n.pnpm-debug.log*\n.next/\nout/\n.env.development.local\n.env.test.local\n.env.production.local\n.pnp*\n.pnp.js\n",
+    "Astro": "node_modules/\nnpm-debug.log*\nyarn-debug.log*\nyarn-error.log*\n.pnpm-debug.log*\ndist/\n.astro/\n.env.production\n",
+    "Python": "__pycache__/\n*.pyc\n*.pyo\n*.pyd\n.Python\nenv/\nvenv/\n.venv/\npip-log.txt\npip-delete-this-directory.txt\n.sqlite\n",
+    "Java": "*.class\n*.jar\n*.war\n*.ear\ntarget/\n.idea/\n*.iml\n.gradle/\nbuild/\n"
+}
+
+const GITIGNORE_OUTPUT_SHARED = ".env\n.env.local\nlogs/\n*.log\n";
+
+type techs = keyof typeof GITIGNORE_OUTPUT_LIST;
+
+import ToolActions from "../../components/tool/ToolActions";
+import ToolTextarea from "../../components/tool/ToolTextarea";
+import Button from "../../ui/Button";
+import CopyButton from "../../ui/CopyButton";
+import { useState } from 'react';
+
+export default function GitignoreGenerator() {
+    const [gitignoreOutput, setGitignoreOutput] = useState("");
+    const [selectedTech, setSelectedTech] = useState<techs | null>(null);
+
+    function clearGitignoreOutput() {
+        setGitignoreOutput("");
+        setSelectedTech(null);
+    }
+
+    function selectTech(tech: techs){
+        if(tech === selectedTech) return; //no un-selecting functionality because there is a clear button
+        setSelectedTech(tech);
+        setGitignoreOutput(GITIGNORE_OUTPUT_SHARED + GITIGNORE_OUTPUT_LIST[tech]);
+    }
+
+    return (
+        <div>
+            <div>
+                <div className="space-y-6">
+                    <div className="grid gap-4 md:grid-cols-2">
+
+                        <div className="flex flex-col justify-center space-y-1">
+                            <label className="text-lg font-semibold tracking-wide uppercase text-secondary">
+                                Technologies & Frameworks
+                            </label>
+                            <p className="text-sm text-muted">
+                                Select the technology/framework to instantly generate your custom .gitignore file.
+                            </p>
+                        </div>
+
+                        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                            {Object.keys(GITIGNORE_OUTPUT_LIST).map((key) => {
+                                const tech = key as techs;
+                                
+                                return(
+                                    <button
+                                        type="button"
+                                        key={tech}
+                                        onClick={() => selectTech(tech)}
+                                        className={`flex items-center justify-center rounded-xl border px-4 py-2.5 text-sm font-medium transition-all active:scale-95 ${(selectedTech === tech) ? 'border-accent bg-accent-bg text-accent shadow-sm shadow-accent/5' : 'border-border bg-surface text-primary hover:border-border-hover hover:bg-elevated'}`}
+                                    >{tech}</button>
+                                )
+                            })}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <ToolTextarea
+                label="Output"
+                value={gitignoreOutput}
+                readOnly
+                textColor="accent"
+                rows={17}
+            />
+
+            <ToolActions className="mt-4">
+                <Button onClick={clearGitignoreOutput}>Clear</Button>
+                <CopyButton value={gitignoreOutput}/>
+            </ToolActions>
+        </div>
+    )
+}

--- a/src/pages/tools/gitignore-generator.astro
+++ b/src/pages/tools/gitignore-generator.astro
@@ -1,0 +1,15 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import GitignoreGenerator from "../../features/gitignore-generator/GitignoreGenerator";
+---
+
+<BaseLayout 
+  title="Gitignore Generator | Free Online Tool"
+  description="Auto Generate .gitignore files for your project. Free, fast, and fully offline-capable web developer utility. No data sent to servers."
+>
+  <h2 class="mb-6 text-2xl font-semibold">
+    .gitignore Generator
+  </h2>
+
+  <GitignoreGenerator client:load/>
+</BaseLayout>


### PR DESCRIPTION
## Summary

Added gitignore generator feature, created a page for it (`.../tools/gitignore-generator`)

Used recommended paths/file names.

Used recommended components `ToolTextarea` and `ToolActions`

Used recommended ui components `Button` and `CopyButton`
-Note: Didn't use `Button` for tech selection because the component didn't fit the use case, instead used `<button>` with custom style.

Ensured that all operations were done on browser, dark/light mode was supported and ui was simple.

Added all the functionality the issue requested.

## Changes

-created `src/features/gitignore-generator.tsx`
-created `src/pages/tools/gitignore-generator.astro`
-modified `src/constants/tools.ts` to add the page button on the main page

## Customization

Gitignore templates can be customized by modifying `GITIGNORE_OUTPUT_LIST` list in the `gitignore-generator.tsx` file.

All the gitignore templates will contain the `GITIGNORE_OUTPUT_SHARED` variable (also in the same file), used for shared ignores like env or logs.

## Related Issue

closes #65 

## Note of contributor

I didn't implement this in order to reach minimum viable product but a nice addition can be changing tech/framework names to logos of those techs/frameworks, this can be easily done by adding a `<img>` inside the `<button>` element of the `gitignore-generator.tsx` file.