### PR TITLE
feat: add CSS Gradient Generator tool

### DIFF
--- a/src/constants/tools.ts
+++ b/src/constants/tools.ts
@@ -144,4 +144,11 @@ export const tools: Tool[] = [
     href: "/tools/json-csv-converter",
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3v18"/><path d="M16 3v18"/><path d="M3 8h18"/><path d="M3 16h18"/><path d="m10 10 4 4"/><path d="m14 10-4 4"/></svg>`,
   },
+  {
+    name: "CSS Gradient Generator",
+    description:
+      "Generate CSS gradients visually with live preview and exportable CSS code.",
+    href: "/tools/css-gradient-generator",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4"/><path d="M12 18v4"/><path d="M2 12h4"/><path d="M18 12h4"/></svg>`,
+  },
 ];

--- a/src/features/css-gradient-generator/CssGradientGenerator.tsx
+++ b/src/features/css-gradient-generator/CssGradientGenerator.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import ToolTextarea from "../../components/tool/ToolTextarea";
+import ToolActions from "../../components/tool/ToolActions";
+import Button from "../../ui/Button";
+import CopyButton from "../../ui/CopyButton";
+
+export default function CssGradientGenerator() {
+  const [color1, setColor1] = useState("#ff0000");
+  const [color2, setColor2] = useState("#0000ff");
+  const [angle, setAngle] = useState(90);
+
+  const cssCode = `background: linear-gradient(${angle}deg, ${color1}, ${color2});`;
+
+  const resetValues = () => {
+    setColor1("#ff0000");
+    setColor2("#0000ff");
+    setAngle(90);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-5 rounded-xl border border-border bg-surface p-5">
+          <div>
+            <label className="mb-2 block text-sm text-secondary">
+              First Color
+            </label>
+
+            <input
+              type="color"
+              value={color1}
+              onChange={(e) => setColor1(e.target.value)}
+              className="h-12 w-full cursor-pointer rounded"
+            />
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm text-secondary">
+              Second Color
+            </label>
+
+            <input
+              type="color"
+              value={color2}
+              onChange={(e) => setColor2(e.target.value)}
+              className="h-12 w-full cursor-pointer rounded"
+            />
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm text-secondary">
+              Angle: {angle}°
+            </label>
+
+            <input
+              type="range"
+              min="0"
+              max="360"
+              value={angle}
+              onChange={(e) => setAngle(Number(e.target.value))}
+              className="w-full"
+            />
+          </div>
+
+          <div>
+            <label className="mb-2 block text-sm text-secondary">
+              Live Preview
+            </label>
+
+            <div
+              className="h-40 w-full rounded-xl border border-border"
+              style={{
+                background: `linear-gradient(${angle}deg, ${color1}, ${color2})`,
+              }}
+            />
+          </div>
+        </div>
+
+        <ToolTextarea
+          label="Generated CSS"
+          value={cssCode}
+          readOnly
+          rows={12}
+          rightLabel={<CopyButton value={cssCode} />}
+        />
+      </div>
+
+      <ToolActions>
+        <Button variant="secondary" onClick={resetValues}>
+          Reset
+        </Button>
+      </ToolActions>
+    </div>
+  );
+}

--- a/src/pages/tools/css-gradient-generator.astro
+++ b/src/pages/tools/css-gradient-generator.astro
@@ -1,0 +1,22 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import CssGradientGenerator from "../../features/css-gradient-generator/CssGradientGenerator";
+---
+
+<BaseLayout
+  title="CSS Gradient Generator | Free Developer Tool"
+  description="Generate CSS gradients visually with live preview and exportable CSS code."
+>
+  <div class="mb-8">
+    <h2 class="text-3xl font-bold text-white tracking-tight mb-2">
+      CSS Gradient Generator
+    </h2>
+
+    <p class="text-neutral-400">
+      Generate linear CSS gradients visually, preview them live, and copy the
+      generated CSS instantly.
+    </p>
+  </div>
+
+  <CssGradientGenerator client:load />
+</BaseLayout>


### PR DESCRIPTION
## Summary

Adds a visual CSS Gradient Generator tool.

### Features

* Generate linear CSS gradients visually
* Live gradient preview
* Adjustable gradient angle
* Color picker controls
* Copy generated CSS
* Reset controls
* Responsive layout
* Dark mode support
* Browser-only implementation

### Testing

* Verified npm install succeeds
* Verified npm run build succeeds before rebase
* Tested color selection
* Tested angle updates
* Tested generated CSS output
* Tested copy functionality

Closes #64
