### PR TITLE
feat: add XML formatter

### DIFF
--- a/src/constants/tools.ts
+++ b/src/constants/tools.ts
@@ -144,4 +144,10 @@ export const tools: Tool[] = [
     href: "/tools/json-csv-converter",
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3v18"/><path d="M16 3v18"/><path d="M3 8h18"/><path d="M3 16h18"/><path d="m10 10 4 4"/><path d="m14 10-4 4"/></svg>`,
   },
+  {
+  name: "XML Formatter",
+  description: "Format and validate XML with clean readable output.",
+  href: "/tools/xml-formatter",
+  icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 9 4 12l4 3"/><path d="m16 9 4 3-4 3"/><path d="m14 4-4 16"/></svg>`,
+},
 ];

--- a/src/features/xml-formatter/XmlFormatter.tsx
+++ b/src/features/xml-formatter/XmlFormatter.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import ToolTextarea from "../../components/tool/ToolTextarea";
+import ToolActions from "../../components/tool/ToolActions";
+import CopyButton from "../../ui/CopyButton";
+import SampleButton from "../../ui/SampleButton";
+import Button from "../../ui/Button";
+
+const SAMPLE_XML =
+  '<root><user><name>DevToolsHub</name><role>Developer</role></user></root>';
+
+function formatXml(xml: string): string {
+  const formatted: string[] = [];
+  const reg = /(>)(<)(\/*)/g;
+
+  xml = xml.replace(reg, "$1\r\n$2$3");
+
+  let pad = 0;
+
+  xml.split("\r\n").forEach((node) => {
+    let indent = 0;
+
+    if (node.match(/^<\/\w/)) {
+      if (pad > 0) {
+        pad -= 1;
+      }
+    } else if (
+      node.match(/^<\w[^>]*[^/]>/) &&
+      !node.includes("</")
+    ) {
+      indent = 1;
+    }
+
+    formatted.push("  ".repeat(pad) + node);
+    pad += indent;
+  });
+
+  return formatted.join("\n");
+}
+
+export default function XmlFormatter() {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+
+  const hasInput = input.trim().length > 0;
+  const canUseOutput = output.length > 0 && output !== "Invalid XML format";
+
+  function handleFormat() {
+    try {
+      const parser = new DOMParser();
+      const xmlDoc = parser.parseFromString(input, "application/xml");
+
+      if (xmlDoc.querySelector("parsererror")) {
+        throw new Error();
+      }
+
+      setOutput(formatXml(input));
+    } catch {
+      setOutput("Invalid XML format");
+    }
+  }
+
+  function loadSample() {
+    setInput(SAMPLE_XML);
+    setOutput(formatXml(SAMPLE_XML));
+  }
+
+  function clear() {
+    setInput("");
+    setOutput("");
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2">
+        <ToolTextarea
+          label="Input"
+          value={input}
+          onChange={setInput}
+          placeholder="Paste XML here..."
+          rows={15}
+          rightLabel={<SampleButton onClick={loadSample} />}
+        />
+
+        <ToolTextarea
+          label="Output"
+          value={output}
+          readOnly
+          rows={15}
+          textColor="accent"
+        >
+          {canUseOutput && (
+            <CopyButton value={output} className="absolute right-4 top-4" />
+          )}
+        </ToolTextarea>
+      </div>
+
+      <div className="hidden md:block">
+        <ToolActions>
+          <Button
+            variant="primary"
+            onClick={handleFormat}
+            isDisabled={!hasInput}
+          >
+            Format XML
+          </Button>
+
+          {output && (
+            <Button variant="secondary" onClick={clear}>
+              Clear
+            </Button>
+          )}
+        </ToolActions>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tools/xml-formatter.astro
+++ b/src/pages/tools/xml-formatter.astro
@@ -1,0 +1,21 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import XmlFormatter from "../../features/xml-formatter/XmlFormatter";
+---
+
+<BaseLayout
+  title="XML Formatter | Free Developer Tool"
+  description="Format and validate XML instantly in your browser."
+>
+  <div class="mb-8">
+    <h2 class="text-3xl font-bold text-white tracking-tight mb-2">
+      XML Formatter
+    </h2>
+
+    <p class="text-neutral-400">
+      Format and validate XML instantly with clean readable output.
+    </p>
+  </div>
+
+  <XmlFormatter client:load />
+</BaseLayout>


### PR DESCRIPTION
## Summary

Adds an XML Formatter tool.

### Features

* Format XML into a clean readable structure
* Validate XML before formatting
* Sample XML button
* Copy output button
* Clear button
* Helpful error message for invalid XML
* Browser-only implementation

### Testing

* Verified XML formatting
* Verified invalid XML handling
* Verified tool registration
* Verified npm run build succeeds

Closes #79
