### PR TITLE
feat: add SQL formatter

### DIFF
--- a/src/constants/tools.ts
+++ b/src/constants/tools.ts
@@ -144,4 +144,11 @@ export const tools: Tool[] = [
     href: "/tools/json-csv-converter",
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3v18"/><path d="M16 3v18"/><path d="M3 8h18"/><path d="M3 16h18"/><path d="m10 10 4 4"/><path d="m14 10-4 4"/></svg>`,
   },
+  {
+  name: "SQL Formatter",
+  description:
+    "Beautify your raw SQL queries with clean spacing and line breaks automatically.",
+  href: "/tools/sql-formatter",
+  icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 7h16"/><path d="M4 12h10"/><path d="M4 17h16"/></svg>`,
+},
 ];

--- a/src/features/sql-formatter/SqlFormatter.tsx
+++ b/src/features/sql-formatter/SqlFormatter.tsx
@@ -59,16 +59,15 @@ export default function SqlFormatter() {
         />
 
         <ToolTextarea
-          label="Output"
-          value={output}
-          readOnly
-          rows={15}
-          textColor="accent"
-        >
-          {canUseOutput && (
-            <CopyButton value={output} className="absolute right-4 top-4" />
-          )}
-        </ToolTextarea>
+  label="Output"
+  value={output}
+  readOnly
+  rows={15}
+  textColor="accent"
+  rightLabel={
+    canUseOutput ? <CopyButton value={output} /> : undefined
+  }
+/>
       </div>
 
       <div className="md:hidden sticky bottom-4 z-10 bg-surface/95 backdrop-blur-sm border border-border rounded-xl p-3 shadow-lg">

--- a/src/features/sql-formatter/SqlFormatter.tsx
+++ b/src/features/sql-formatter/SqlFormatter.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import ToolTextarea from "../../components/tool/ToolTextarea";
+import ToolActions from "../../components/tool/ToolActions";
+import CopyButton from "../../ui/CopyButton";
+import SampleButton from "../../ui/SampleButton";
+import Button from "../../ui/Button";
+
+const SAMPLE_SQL =
+  "select id,name,email from users where active=1 order by created_at desc";
+
+function formatSql(sql: string): string {
+  return sql
+    .replace(/\s+/g, " ")
+    .replace(/\bselect\b/gi, "SELECT")
+    .replace(/\bfrom\b/gi, "\nFROM")
+    .replace(/\bwhere\b/gi, "\nWHERE")
+    .replace(/\binner join\b/gi, "\nINNER JOIN")
+    .replace(/\bleft join\b/gi, "\nLEFT JOIN")
+    .replace(/\bright join\b/gi, "\nRIGHT JOIN")
+    .replace(/\bjoin\b/gi, "\nJOIN")
+    .replace(/\bgroup by\b/gi, "\nGROUP BY")
+    .replace(/\border by\b/gi, "\nORDER BY")
+    .replace(/\bhaving\b/gi, "\nHAVING")
+    .replace(/\blimit\b/gi, "\nLIMIT")
+    .trim();
+}
+
+export default function SqlFormatter() {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+
+  const hasInput = input.trim().length > 0;
+  const canUseOutput = output.length > 0;
+
+  function handleFormat() {
+    setOutput(formatSql(input));
+  }
+
+  function loadSample() {
+    setInput(SAMPLE_SQL);
+    setOutput(formatSql(SAMPLE_SQL));
+  }
+
+  function clear() {
+    setInput("");
+    setOutput("");
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2">
+        <ToolTextarea
+          label="Input"
+          value={input}
+          onChange={setInput}
+          placeholder="Paste SQL query here..."
+          rows={15}
+          rightLabel={<SampleButton onClick={loadSample} />}
+        />
+
+        <ToolTextarea
+          label="Output"
+          value={output}
+          readOnly
+          rows={15}
+          textColor="accent"
+        >
+          {canUseOutput && (
+            <CopyButton value={output} className="absolute right-4 top-4" />
+          )}
+        </ToolTextarea>
+      </div>
+
+      <div className="md:hidden sticky bottom-4 z-10 bg-surface/95 backdrop-blur-sm border border-border rounded-xl p-3 shadow-lg">
+        <div className="flex gap-2">
+          <Button
+            variant="primary"
+            onClick={handleFormat}
+            isDisabled={!hasInput}
+            className="flex-1"
+          >
+            Format SQL
+          </Button>
+
+          {output && (
+            <Button variant="secondary" onClick={clear}>
+              Clear
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="hidden md:block">
+        <ToolActions>
+          <Button
+            variant="primary"
+            onClick={handleFormat}
+            isDisabled={!hasInput}
+          >
+            Format SQL
+          </Button>
+
+          {output && (
+            <Button variant="secondary" onClick={clear}>
+              Clear
+            </Button>
+          )}
+        </ToolActions>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tools/sql-formatter.astro
+++ b/src/pages/tools/sql-formatter.astro
@@ -1,0 +1,21 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import SqlFormatter from "../../features/sql-formatter/SqlFormatter";
+---
+
+<BaseLayout
+  title="SQL Formatter | Free Developer Tool"
+  description="Beautify your raw SQL queries with clean spacing and line breaks automatically."
+>
+  <div class="mb-8">
+    <h2 class="text-3xl font-bold text-white tracking-tight mb-2">
+      SQL Formatter
+    </h2>
+
+    <p class="text-neutral-400">
+      Format SQL queries into clean, readable statements.
+    </p>
+  </div>
+
+  <SqlFormatter client:load />
+</BaseLayout>


### PR DESCRIPTION
## Summary

Adds a SQL Formatter tool.

### Features

* Format raw SQL queries into readable statements
* SQL keyword capitalization
* Automatic line breaks for common clauses
* Sample SQL button
* Copy output button
* Clear button
* Browser-only implementation

### Testing

* Verified SQL formatting output
* Verified sample loading
* Verified copy functionality
* Verified tool registration
* Verified npm run build succeeds

Closes #50
