### PR TITLE
fix: restore light-theme readability on affected tool pages

### DIFF
--- a/src/features/css-unit-converter/CssUnitConverter.tsx
+++ b/src/features/css-unit-converter/CssUnitConverter.tsx
@@ -67,20 +67,20 @@ export default function CssUnitConverter() {
 
   return (
     <div className="space-y-6">
-      <div className="rounded-xl border border-border bg-surface p-4 space-y-4">
+      <div className="space-y-4 rounded-xl border border-border bg-surface p-4">
         <input
           type="number"
           value={value}
           onChange={(e) => setValue(e.target.value)}
           placeholder="Enter value"
-          className="w-full rounded-lg border border-border bg-background p-3"
+          className="w-full rounded-lg border border-border bg-background p-3 text-primary"
         />
 
         <div className="grid grid-cols-2 gap-4">
           <select
             value={fromUnit}
             onChange={(e) => setFromUnit(e.target.value)}
-            className="rounded-lg border border-border bg-background p-3"
+            className="rounded-lg border border-border bg-background p-3 text-primary"
           >
             {UNITS.map((unit) => (
               <option key={unit}>{unit}</option>
@@ -90,7 +90,7 @@ export default function CssUnitConverter() {
           <select
             value={toUnit}
             onChange={(e) => setToUnit(e.target.value)}
-            className="rounded-lg border border-border bg-background p-3"
+            className="rounded-lg border border-border bg-background p-3 text-primary"
           >
             {UNITS.map((unit) => (
               <option key={unit}>{unit}</option>
@@ -113,7 +113,7 @@ export default function CssUnitConverter() {
         <div className="flex items-center justify-between">
           <div>
             <p className="text-xs text-secondary">Result</p>
-            <p className="font-mono text-lg">
+            <p className="font-mono text-lg text-primary">
               {result} {toUnit}
             </p>
           </div>

--- a/src/pages/tools/color-converter.astro
+++ b/src/pages/tools/color-converter.astro
@@ -8,10 +8,10 @@ import ColorConverterTool from "../../features/color-converter/ColorConverter";
   description="Convert colors between HEX, RGB, HSL, and CSS named colors instantly. Free, fast, and fully offline developer tool. No data sent to servers."
 >
   <div class="mb-8">
-    <h2 class="text-3xl font-bold text-white tracking-tight mb-2">
+    <h2 class="mb-2 text-3xl font-bold tracking-tight text-primary">
       Color Converter
     </h2>
-    <p class="text-neutral-400">
+    <p class="text-secondary">
       Convert colors between HEX, RGB, HSL, and CSS named formats with a live
       preview.
     </p>

--- a/src/pages/tools/css-gradient-generator.astro
+++ b/src/pages/tools/css-gradient-generator.astro
@@ -8,11 +8,11 @@ import CssGradientGenerator from "../../features/css-gradient-generator/CssGradi
   description="Generate CSS gradients visually with live preview and exportable CSS code."
 >
   <div class="mb-8">
-    <h2 class="text-3xl font-bold text-white tracking-tight mb-2">
+    <h2 class="mb-2 text-3xl font-bold tracking-tight text-primary">
       CSS Gradient Generator
     </h2>
 
-    <p class="text-neutral-400">
+    <p class="text-secondary">
       Generate linear CSS gradients visually, preview them live, and copy the
       generated CSS instantly.
     </p>

--- a/src/pages/tools/css-unit-converter.astro
+++ b/src/pages/tools/css-unit-converter.astro
@@ -8,11 +8,11 @@ import CssUnitConverter from "../../features/css-unit-converter/CssUnitConverter
   description="Convert between px, em, rem, %, vw and vh instantly."
 >
   <div class="mb-8">
-    <h2 class="text-3xl font-bold text-white tracking-tight mb-2">
+    <h2 class="mb-2 text-3xl font-bold tracking-tight text-primary">
       CSS Unit Converter
     </h2>
 
-    <p class="text-neutral-400">
+    <p class="text-secondary">
       Convert between common CSS units instantly.
     </p>
   </div>

--- a/src/pages/tools/hash-generator.astro
+++ b/src/pages/tools/hash-generator.astro
@@ -8,8 +8,8 @@ import HashGenerator from "../../features/hash-generator/HashGenerator";
   description="Free, offline-first tool to generate SHA-1, SHA-256, SHA-384, and SHA-512 hashes. Support for HMAC keys. 100% secure client-side cryptography."
 >
   <div class="mb-8">
-    <h1 class="text-3xl font-bold text-white mb-2">Hash Generator</h1>
-    <p class="text-neutral-400">
+    <h1 class="mb-2 text-3xl font-bold text-primary">Hash Generator</h1>
+    <p class="text-secondary">
       Securely generate SHA-1, SHA-256, SHA-384, and SHA-512 hashes locally.
     </p>
   </div>

--- a/src/pages/tools/jwt-decoder.astro
+++ b/src/pages/tools/jwt-decoder.astro
@@ -8,10 +8,10 @@ import JWTDecoder from "../../features/jwt-decoder/JWTDecoder";
   description="Decode and inspect JSON Web Tokens (JWT) locally and securely. No data sent to servers. Free offline web developer tool."
 >
   <div class="mb-8">
-    <h2 class="text-3xl font-bold text-white tracking-tight mb-2">
+    <h2 class="mb-2 text-3xl font-bold tracking-tight text-primary">
       JWT Decoder
     </h2>
-    <p class="text-neutral-400">
+    <p class="text-secondary">
       Decode JSON Web Tokens locally and inspect their contents.
     </p>
   </div>

--- a/src/pages/tools/sql-formatter.astro
+++ b/src/pages/tools/sql-formatter.astro
@@ -8,11 +8,11 @@ import SqlFormatter from "../../features/sql-formatter/SqlFormatter";
   description="Beautify your raw SQL queries with clean spacing and line breaks automatically."
 >
   <div class="mb-8">
-    <h2 class="text-3xl font-bold text-white tracking-tight mb-2">
+    <h2 class="mb-2 text-3xl font-bold tracking-tight text-primary">
       SQL Formatter
     </h2>
 
-    <p class="text-neutral-400">
+    <p class="text-secondary">
       Format SQL queries into clean, readable statements.
     </p>
   </div>

--- a/src/pages/tools/xml-formatter.astro
+++ b/src/pages/tools/xml-formatter.astro
@@ -8,11 +8,11 @@ import XmlFormatter from "../../features/xml-formatter/XmlFormatter";
   description="Format and validate XML instantly in your browser."
 >
   <div class="mb-8">
-    <h2 class="text-3xl font-bold text-white tracking-tight mb-2">
+    <h2 class="mb-2 text-3xl font-bold tracking-tight text-primary">
       XML Formatter
     </h2>
 
-    <p class="text-neutral-400">
+    <p class="text-secondary">
       Format and validate XML instantly with clean readable output.
     </p>
   </div>


### PR DESCRIPTION
## What changed
- replaced hardcoded `text-white` and `text-neutral-400` hero copy styles on the affected tool pages with shared theme tokens
- added explicit `text-primary` styling to the CSS Unit Converter input, selects, and result output so those fields stay readable in light theme

## Related issue
closes #96

## Validation
- `pnpm build`

## Notes
- kept the change scoped to the pages and controls listed in the issue
- did not run browser screenshots locally because only build validation was available in this environment