### PR TITLE
feat: add CSS Clamp Generator tool

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
 allowBuilds:
   esbuild: true
   sharp: true
-  tree-sitter: set this to true or false
-  tree-sitter-bash: set this to true or false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 allowBuilds:
   esbuild: true
   sharp: true
+  tree-sitter: set this to true or false
+  tree-sitter-bash: set this to true or false

--- a/src/constants/tools.ts
+++ b/src/constants/tools.ts
@@ -176,4 +176,14 @@ export const tools: Tool[] = [
   href: "/tools/css-gradient-generator",
   icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4"/><path d="M12 18v4"/><path d="M2 12h4"/><path d="M18 12h4"/></svg>`,
 },
+{
+  name: "CSS Clamp Generator",
+  description: "Generate responsive CSS clamp() expressions with live preview.",
+  href: "/tools/css-clamp-generator",
+  icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M8 4h8"/>
+    <path d="M8 20h8"/>
+    <path d="M12 4v16"/>
+  </svg>`,
+},
 ];

--- a/src/features/css-clamp-generator/CssClampGenerator.tsx
+++ b/src/features/css-clamp-generator/CssClampGenerator.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import CopyButton from "../../ui/CopyButton";
+
+export default function CssClampGenerator() {
+  const [property, setProperty] = useState("font-size");
+  const [min, setMin] = useState("1rem");
+  const [preferred, setPreferred] = useState("2vw");
+  const [max, setMax] = useState("2rem");
+
+  const clampValue = `clamp(${min}, ${preferred}, ${max})`;
+  const cssOutput = `${property}: ${clampValue};`;
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4">
+        <div>
+          <label className="mb-2 block text-sm font-medium">
+            CSS Property
+          </label>
+
+          <select
+            value={property}
+            onChange={(e) => setProperty(e.target.value)}
+            className="w-full rounded-xl border border-border bg-surface p-3"
+          >
+            <option value="font-size">font-size</option>
+            <option value="width">width</option>
+            <option value="height">height</option>
+            <option value="padding">padding</option>
+            <option value="margin">margin</option>
+            <option value="gap">gap</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="mb-2 block text-sm font-medium">
+            Minimum Value
+          </label>
+
+          <input
+            value={min}
+            placeholder="1rem"
+            onChange={(e) => setMin(e.target.value)}
+            className="w-full rounded-xl border border-border bg-surface p-3"
+          />
+        </div>
+
+        <div>
+          <label className="mb-2 block text-sm font-medium">
+            Preferred Value
+          </label>
+
+          <input
+            value={preferred}
+            placeholder="2vw"
+            onChange={(e) => setPreferred(e.target.value)}
+            className="w-full rounded-xl border border-border bg-surface p-3"
+          />
+        </div>
+
+        <div>
+          <label className="mb-2 block text-sm font-medium">
+            Maximum Value
+          </label>
+
+          <input
+            value={max}
+            placeholder="2rem"
+            onChange={(e) => setMax(e.target.value)}
+            className="w-full rounded-xl border border-border bg-surface p-3"
+          />
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-border bg-surface p-4">
+        <p className="mb-3 text-sm font-medium">
+          Generated CSS
+        </p>
+
+        <div className="relative">
+          <pre className="overflow-auto rounded-xl bg-background p-4 text-sm">
+            {cssOutput}
+          </pre>
+
+          <CopyButton
+            value={cssOutput}
+            className="absolute right-2 top-2"
+          />
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-border bg-surface p-6">
+        <p className="mb-3 text-sm font-medium">
+          Live Preview
+        </p>
+
+        <p
+          style={{ [property]: clampValue } as React.CSSProperties}
+          className="font-semibold"
+        >
+          Responsive Preview Text
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tools/css-clamp-generator.astro
+++ b/src/pages/tools/css-clamp-generator.astro
@@ -1,0 +1,15 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import CssClampGenerator from "../../features/css-clamp-generator/CssClampGenerator";
+---
+
+<BaseLayout
+  title="CSS Clamp Generator"
+  description="Generate responsive CSS clamp() values with live preview."
+>
+  <h2 class="mb-6 text-2xl font-semibold">
+    CSS Clamp Generator
+  </h2>
+
+  <CssClampGenerator client:load />
+</BaseLayout>


### PR DESCRIPTION
## Summary

Adds a CSS Clamp Generator tool that helps developers create responsive CSS `clamp()` expressions with live preview and copyable output.

## Features

* Generate CSS `clamp()` expressions
* Minimum value input
* Preferred value input
* Maximum value input
* CSS property selector
* Real-time output updates
* Live responsive preview
* Copy generated CSS
* Browser-only implementation

## Implementation

### Component

`src/features/css-clamp-generator/CssClampGenerator.tsx`

* Generates responsive `clamp()` expressions dynamically
* Supports multiple CSS properties
* Updates output and preview in real time
* Provides copy-to-clipboard functionality

### Page

`src/pages/tools/css-clamp-generator.astro`

* Renders the tool with client-side hydration

### Registration

Added the tool to:

`src/constants/tools.ts`

## Verification

✅ Build succeeds without errors

✅ Route generated: `/tools/css-clamp-generator`

✅ Clamp expression updates in real time

✅ Live preview reflects current values

✅ Copy functionality works correctly

✅ Responsive layout

✅ No console errors

## Example Output

```css
font-size: clamp(1rem, 2vw, 2rem);
```

## Related

Closes #104
