### PR TITLE
feat(grid): add CSS Grid Generator tool

### DIFF
--- a/src/constants/tools.ts
+++ b/src/constants/tools.ts
@@ -176,4 +176,11 @@ export const tools: Tool[] = [
   href: "/tools/css-gradient-generator",
   icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4"/><path d="M12 18v4"/><path d="M2 12h4"/><path d="M18 12h4"/></svg>`,
 },
+  {
+    name: "CSS Grid Generator",
+    description:
+      "Visually configure CSS Grid layouts and generate copyable CSS with live preview.",
+    href: "/tools/grid-generator",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="8" height="8"/><rect x="13" y="3" width="8" height="8"/><rect x="3" y="13" width="8" height="8"/><rect x="13" y="13" width="8" height="8"/></svg>`,
+  },
 ];

--- a/src/features/grid-generator/GridGenerator.tsx
+++ b/src/features/grid-generator/GridGenerator.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useState } from "react";
+import CopyButton from "../../ui/CopyButton";
+
+export default function GridGenerator() {
+  const [columns, setColumns] = useState("repeat(3, 1fr)");
+  const [rows, setRows] = useState("auto");
+  const [gap, setGap] = useState("16px");
+  const [justifyItems, setJustifyItems] = useState("center");
+  const [alignItems, setAlignItems] = useState("center");
+
+  const cssOutput = useMemo(() => {
+    return `display: grid;\ngrid-template-columns: ${columns};\ngrid-template-rows: ${rows};\ngap: ${gap};\njustify-items: ${justifyItems};\nalign-items: ${alignItems};`;
+  }, [columns, rows, gap, justifyItems, alignItems]);
+
+  const previewStyles = useMemo(() => ({
+    display: "grid",
+    gridTemplateColumns: columns as React.CSSProperties["gridTemplateColumns"],
+    gridTemplateRows: rows as React.CSSProperties["gridTemplateRows"],
+    gap,
+    justifyItems: justifyItems as React.CSSProperties["justifyItems"],
+    alignItems: alignItems as React.CSSProperties["alignItems"],
+    padding: "1rem",
+    minHeight: "220px",
+    backgroundColor: "rgba(99, 102, 241, 0.04)",
+    borderRadius: "0.75rem",
+  }), [columns, rows, gap, justifyItems, alignItems]);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label className="mb-2 block text-sm font-medium">Grid Template Columns</label>
+          <input
+            value={columns}
+            onChange={(e) => setColumns(e.target.value)}
+            placeholder="repeat(3, 1fr)"
+            className="w-full rounded-xl border border-border bg-surface p-3"
+          />
+          <p className="mt-2 text-xs text-secondary">Examples: <code>repeat(3, 1fr)</code>, <code>200px 1fr</code></p>
+        </div>
+
+        <div>
+          <label className="mb-2 block text-sm font-medium">Grid Template Rows</label>
+          <input
+            value={rows}
+            onChange={(e) => setRows(e.target.value)}
+            placeholder="auto"
+            className="w-full rounded-xl border border-border bg-surface p-3"
+          />
+          <p className="mt-2 text-xs text-secondary">Examples: <code>auto</code>, <code>100px 1fr</code></p>
+        </div>
+
+        <div>
+          <label className="mb-2 block text-sm font-medium">Gap</label>
+          <input
+            value={gap}
+            onChange={(e) => setGap(e.target.value)}
+            placeholder="16px"
+            className="w-full rounded-xl border border-border bg-surface p-3"
+          />
+        </div>
+
+        <div>
+          <label className="mb-2 block text-sm font-medium">Justify Items</label>
+          <select
+            value={justifyItems}
+            onChange={(e) => setJustifyItems(e.target.value)}
+            className="w-full rounded-xl border border-border bg-surface p-3"
+          >
+            <option value="start">start</option>
+            <option value="center">center</option>
+            <option value="end">end</option>
+            <option value="stretch">stretch</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="mb-2 block text-sm font-medium">Align Items</label>
+          <select
+            value={alignItems}
+            onChange={(e) => setAlignItems(e.target.value)}
+            className="w-full rounded-xl border border-border bg-surface p-3"
+          >
+            <option value="start">start</option>
+            <option value="center">center</option>
+            <option value="end">end</option>
+            <option value="stretch">stretch</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-border bg-surface p-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <p className="text-sm font-medium">Generated CSS</p>
+          <CopyButton value={cssOutput} />
+        </div>
+
+        <pre className="overflow-auto rounded-xl bg-background p-4 text-sm">
+          {cssOutput}
+        </pre>
+      </div>
+
+      <div className="rounded-2xl border border-border bg-surface p-6">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <p className="text-sm font-medium">Live Preview</p>
+          <span className="rounded-full bg-muted px-3 py-1 text-xs text-secondary">{columns} • {rows} • gap {gap}</span>
+        </div>
+
+        <div className="rounded-3xl border border-border p-4">
+          <div style={previewStyles}>
+            <div className="rounded-lg bg-primary/10 px-3 py-2 text-sm font-medium text-primary">1</div>
+            <div className="rounded-lg bg-primary/10 px-3 py-2 text-sm font-medium text-primary">2</div>
+            <div className="rounded-lg bg-primary/10 px-3 py-2 text-sm font-medium text-primary">3</div>
+            <div className="rounded-lg bg-primary/10 px-3 py-2 text-sm font-medium text-primary">4</div>
+            <div className="rounded-lg bg-primary/10 px-3 py-2 text-sm font-medium text-primary">5</div>
+            <div className="rounded-lg bg-primary/10 px-3 py-2 text-sm font-medium text-primary">6</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tools/grid-generator.astro
+++ b/src/pages/tools/grid-generator.astro
@@ -1,0 +1,13 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import GridGenerator from "../../features/grid-generator/GridGenerator";
+---
+
+<BaseLayout
+  title="CSS Grid Generator | Free Online Developer Tool"
+  description="Visually configure CSS Grid properties and generate copyable CSS with live preview."
+>
+  <h2 class="mb-6 text-2xl font-semibold">CSS Grid Generator</h2>
+
+  <GridGenerator client:load />
+</BaseLayout>


### PR DESCRIPTION
## Summary

Add `GridGenerator`, a browser-only tool that enables developers to visually configure CSS Grid layouts and generate copyable CSS with a live preview.

## Changes

### New Files

* **Component:** `GridGenerator.tsx`
* **Page:** `grid-generator.astro`
* **Registry:** `tools.ts`

### Features

* Controls for:

  * `grid-template-columns`
  * `grid-template-rows`
  * `gap`
* Selectors for:

  * `justify-items`
  * `align-items`
* Real-time CSS generation
* Copy-to-clipboard support using the existing `CopyButton` component
* Interactive live preview with sample grid items reflecting current settings

## Implementation Details

* Loaded client-side using `client:load` to ensure browser-only behavior.
* Follows existing design patterns, styling conventions, and UI tokens used throughout the project.
* Keeps state and preview synchronized for instant visual feedback.

## Testing

* Manually verified that all controls update the preview in real time.
* Verified generated CSS matches the selected configuration.
* Verified copy functionality correctly copies generated CSS.
* Type-checked new files locally with no compilation errors.

## Benefits

This tool simplifies CSS Grid layout creation by providing immediate visual feedback and ready-to-use CSS output. It reduces trial-and-error during development, serves as a learning aid for developers, and complements the repository's existing layout utilities such as the Flexbox Generator.

Closes #110
