### PR TITLE
feat: add Bcrypt Generator & Validator tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "astro": "^6.1.9",
+    "bcryptjs": "^3.0.3",
     "curlconverter": "^4.12.0",
     "dompurify": "^3.4.7",
     "fuse.js": "^7.3.0",
@@ -36,6 +37,7 @@
     "vite": "^7"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^3.0.0",
     "@types/dompurify": "^3.2.0",
     "@types/papaparse": "^5.5.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       astro:
         specifier: ^6.1.9
         version: 6.1.9(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.9.0)
+      bcryptjs:
+        specifier: ^3.0.3
+        version: 3.0.3
       curlconverter:
         specifier: ^4.12.0
         version: 4.12.0
@@ -66,6 +69,9 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
     devDependencies:
+      '@types/bcryptjs':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
@@ -812,6 +818,10 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/bcryptjs@3.0.0':
+    resolution: {integrity: sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==}
+    deprecated: This is a stub types definition. bcryptjs provides its own type definitions, so you do not need this installed.
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -899,6 +909,10 @@ packages:
   baseline-browser-mapping@2.10.23:
     resolution: {integrity: sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  bcryptjs@3.0.3:
+    resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
   boolbase@1.0.0:
@@ -1774,6 +1788,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -2611,6 +2626,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/bcryptjs@3.0.0':
+    dependencies:
+      bcryptjs: 3.0.3
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -2785,6 +2804,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.10.23: {}
+
+  bcryptjs@3.0.3: {}
 
   boolbase@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 allowBuilds:
   esbuild: true
   sharp: true
-  tree-sitter: set this to true or false
-  tree-sitter-bash: set this to true or false
+  tree-sitter: false
+  tree-sitter-bash: false

--- a/src/constants/tools.ts
+++ b/src/constants/tools.ts
@@ -270,4 +270,11 @@ export const tools: Tool[] = [
     href: "/tools/jwt-generator-validator",
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M12 8v4"/><path d="M8 12h8"/></svg>`,
   },
+  {
+  name: "Bcrypt Generator & Validator",
+  description:
+    "Generate bcrypt hashes with configurable salt rounds and validate plaintext against existing hashes. Runs entirely in your browser.",
+  href: "/tools/bcrypt-generator",
+  icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>`,
+},
 ];

--- a/src/features/bcrypt-generator/BcryptGeneratorTool.tsx
+++ b/src/features/bcrypt-generator/BcryptGeneratorTool.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+import * as bcrypt from "bcryptjs";
+import ToolTextarea from "../../components/tool/ToolTextarea";
+import CopyButton from "../../ui/CopyButton";
+import ToolActions from "../../components/tool/ToolActions";
+import Button from "../../ui/Button";
+import SampleButton from "../../ui/SampleButton";
+
+export default function BcryptGeneratorTool() {
+  const [genInput, setGenInput] = useState("");
+  const [saltRounds, setSaltRounds] = useState(10);
+  const [genOutput, setGenOutput] = useState("");
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const [valPlaintext, setValPlaintext] = useState("");
+  const [valHash, setValHash] = useState("");
+  const [valResult, setValResult] = useState<"match" | "no-match" | null>(null);
+  const [isValidating, setIsValidating] = useState(false);
+
+  async function handleGenerate() {
+    if (!genInput) return;
+    setIsGenerating(true);
+    try {
+      const hash = await bcrypt.hash(genInput, saltRounds);
+      setGenOutput(hash);
+    } catch {
+      setGenOutput("Error generating hash");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  async function handleValidate() {
+    if (!valPlaintext || !valHash) return;
+    setIsValidating(true);
+    try {
+      const match = await bcrypt.compare(valPlaintext, valHash);
+      setValResult(match ? "match" : "no-match");
+    } catch {
+      setValResult("no-match");
+    } finally {
+      setIsValidating(false);
+    }
+  }
+
+  function clearGenerator() {
+    setGenInput("");
+    setGenOutput("");
+  }
+
+  function clearValidator() {
+    setValPlaintext("");
+    setValHash("");
+    setValResult(null);
+  }
+
+  function loadSample() {
+    setGenInput("mypassword123");
+    setSaltRounds(10);
+  }
+
+  return (
+    <div className="space-y-10">
+      <div className="space-y-6">
+        <h2 className="text-lg font-semibold text-primary">Generator</h2>
+        <div className="flex flex-wrap items-center gap-4 rounded-xl border border-border bg-surface/50 p-4">
+          <span className="text-sm font-medium text-secondary">Salt Rounds:</span>
+          <div className="flex flex-wrap gap-2">
+            {[8, 10, 12, 14].map((r) => (
+              <button
+                key={r}
+                onClick={() => setSaltRounds(r)}
+                className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-all ${
+                  saltRounds === r
+                    ? "bg-accent text-white shadow-lg shadow-accent/20"
+                    : "bg-elevated text-secondary hover:bg-border hover:text-primary"
+                }`}
+              >
+                {r}
+              </button>
+            ))}
+          </div>
+          <span className="text-xs text-secondary ml-auto">Higher = more secure but slower</span>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          <ToolTextarea
+            label="Plaintext"
+            value={genInput}
+            onChange={setGenInput}
+            placeholder="Enter text to hash..."
+            rows={6}
+            rightLabel={<SampleButton onClick={loadSample} />}
+          />
+          <ToolTextarea label="Bcrypt Hash" value={genOutput} readOnly rows={6} textColor="accent">
+            {genOutput && !genOutput.startsWith("Error") && (
+              <CopyButton value={genOutput} className="absolute right-4 top-4" />
+            )}
+          </ToolTextarea>
+        </div>
+        <ToolActions>
+          <Button onClick={handleGenerate} variant="primary" isDisabled={!genInput || isGenerating}>
+            {isGenerating ? "Generating..." : "Generate Hash"}
+          </Button>
+          <Button onClick={clearGenerator} variant="secondary" isDisabled={!genInput && !genOutput}>
+            Clear
+          </Button>
+        </ToolActions>
+      </div>
+
+      <div className="h-px w-full bg-border" />
+
+      <div className="space-y-6">
+        <h2 className="text-lg font-semibold text-primary">Validator</h2>
+        <div className="grid gap-6 md:grid-cols-2">
+          <ToolTextarea
+            label="Plaintext"
+            value={valPlaintext}
+            onChange={setValPlaintext}
+            placeholder="Enter plaintext to verify..."
+            rows={4}
+          />
+          <ToolTextarea
+            label="Bcrypt Hash"
+            value={valHash}
+            onChange={setValHash}
+            placeholder="Paste bcrypt hash here..."
+            rows={4}
+          />
+        </div>
+        {valResult && (
+          <div className={`rounded-xl border p-4 text-sm font-medium text-center transition-all ${
+            valResult === "match"
+              ? "border-green-500/30 bg-green-500/10 text-green-400"
+              : "border-red-500/30 bg-red-500/10 text-red-400"
+          }`}>
+            {valResult === "match"
+              ? "✅ Match — plaintext matches the hash"
+              : "❌ No Match — plaintext does not match the hash"}
+          </div>
+        )}
+        <ToolActions>
+          <Button onClick={handleValidate} variant="primary" isDisabled={!valPlaintext || !valHash || isValidating}>
+            {isValidating ? "Validating..." : "Validate"}
+          </Button>
+          <Button onClick={clearValidator} variant="secondary" isDisabled={!valPlaintext && !valHash && !valResult}>
+            Clear
+          </Button>
+        </ToolActions>
+      </div>
+
+      <div className="rounded-xl border border-border bg-surface/50 p-4 text-sm text-secondary">
+        <p>
+          <strong>Security Note:</strong> All hashing and validation is performed locally in your browser using bcryptjs. Your data never leaves your device.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/tools/bcrypt-generator.astro
+++ b/src/pages/tools/bcrypt-generator.astro
@@ -1,0 +1,18 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import BcryptGeneratorTool from "../../features/bcrypt-generator/BcryptGeneratorTool";
+---
+
+<BaseLayout
+  title="Bcrypt Generator & Validator | Secure Password Hashing"
+  description="Generate bcrypt hashes from plaintext and verify whether a plaintext value matches an existing bcrypt hash. All operations are performed client-side."
+>
+  <div class="mb-8">
+    <h1 class="mb-2 text-3xl font-bold text-primary">Bcrypt Generator & Validator</h1>
+    <p class="text-secondary">
+      Generate bcrypt hashes with configurable salt rounds and validate plaintext against existing hashes. Runs entirely in your browser.
+    </p>
+  </div>
+
+  <BcryptGeneratorTool client:load />
+</BaseLayout>


### PR DESCRIPTION
## Summary
Added a new Bcrypt Generator & Validator tool that allows users to generate bcrypt hashes with configurable salt rounds and validate plaintext against existing hashes, all client-side.

## Changes
- Added `src/features/bcrypt-generator/BcryptGeneratorTool.tsx` — new tool component with Generator and Validator sections
- Added `src/pages/tools/bcrypt-generator.astro` — new page route
- Updated `src/constants/tools.ts` — registered the tool in the tools list
- Installed `bcryptjs` for client-side hashing

## Related Issue
Closes #127
